### PR TITLE
Do not compare short discriminator with long

### DIFF
--- a/src/devman/mod.rs
+++ b/src/devman/mod.rs
@@ -239,7 +239,11 @@ impl DeviceManager {
                         }
                     };
                     if let Some(ref d) = matter_info.discriminator {
-                        if *d == discriminator.to_string() {
+                        let mut mdns_discriminator = d.parse::<u16>()?;
+                        if info.is_short_discriminator {
+                            mdns_discriminator &= 0xf00;
+                        }
+                        if mdns_discriminator == discriminator {
                             self.mdns.remove_query("_matterc._udp.local").await;
                             break (matter_info.ips, matter_info.port.unwrap_or(5540));
                         }


### PR DESCRIPTION
Hi, happy to see this library exist :)

Trying the example controller with the first Matter device I could get my hands on, a WiZ downlight, got stuck on:

```
[2026-05-04T03:17:47.643Z INFO  matc::devman] Discovering device with discriminator 256...
```

because in the mDNS response it was `D=339`, not 256! So the discriminator provided in the mDNS TXT record is not necessarily the short one.

Mask out the "long" bits when comparing against the short discriminator from the 11 char setup code.
