### PR TITLE
fix: Add ArmFailSafe to IP Commissioning Path

### DIFF
--- a/src/commission.rs
+++ b/src/commission.rs
@@ -14,7 +14,6 @@ const CMD_OPERATIONAL_CSRREQUEST: u32 = 0x4;
 //const CMD_OPERATIONAL_CERTCHAIN_REQUEST: u32 = 0x2;
 
 const CLUSTER_GENERAL_COMMISSIONING: u32 = 0x30;
-#[cfg(feature = "ble")]
 const CMD_GENERAL_COMMISSIONING_ARMFAILSAFE: u32 = 0;
 //const CMD_GENERAL_COMMISSIONING_SETREGULATORYCONFIG: u32 = 2;
 const CMD_GENERAL_COMMISSIONING_COMMISSIONINGCOMPLETE: u32 = 4;
@@ -287,18 +286,19 @@ pub(crate) async fn commission(
     let mut retrctx = retransmit::RetrContext::new(connection, session);
     let base: u16 = rand::random();
 
-    let csrd = send_csr(&mut retrctx, base).await?;
+    arm_failsafe(&mut retrctx, 60, base).await?;
 
-    push_ca_cert(&mut retrctx, cm, base.wrapping_add(1)).await?;
+    let csrd = send_csr(&mut retrctx, base.wrapping_add(1)).await?;
 
-    push_device_cert(&mut retrctx, cm, csrd, node_id, controller_id, fabric, base.wrapping_add(2)).await?;
+    push_ca_cert(&mut retrctx, cm, base.wrapping_add(2)).await?;
+
+    push_device_cert(&mut retrctx, cm, csrd, node_id, controller_id, fabric, base.wrapping_add(3)).await?;
 
     let ses = commissioning_complete(connection, cm, node_id, controller_id, fabric).await?;
 
     Ok(ses)
 }
 
-#[cfg(feature = "ble")]
 async fn arm_failsafe(
     retrctx: &mut retransmit::RetrContext<'_>,
     timeout_secs: u16,


### PR DESCRIPTION
Please consider this AI generated patch. I has solved my issue with matter bridge commissioning.

# Fix: Add ArmFailSafe to IP Commissioning Path

## Problem

When commissioning a Matter device over IP (Ethernet/Wi-Fi), the matc controller
skipped the mandatory `ArmFailSafe` command. The Matter specification requires
`ArmFailSafe` to be sent before `CSRRequest` to open a commissioning window on
the device side.

As a result, bridges and devices implementing the spec strictly (such as rs-matter)
rejected the `CSRRequest` with status code `0xCA` (`IMStatusCode::FailSafeRequired`,
decimal 202), causing commissioning to fail immediately.

The `arm_failsafe` function and its associated constant
`CMD_GENERAL_COMMISSIONING_ARMFAILSAFE` existed in the codebase but were gated
behind `#[cfg(feature = "ble")]`, making them unavailable for the standard IP path.

## Fix

- Removed the `#[cfg(feature = "ble")]` guard from `CMD_GENERAL_COMMISSIONING_ARMFAILSAFE`
  and from the `arm_failsafe` async function, making both available unconditionally.
- Added an `arm_failsafe` call as the first step inside `commission()`, before
  `send_csr`. A 60-second timeout is requested, which is the standard value used
  during commissioning.
- Shifted all subsequent exchange IDs by +1 (using `wrapping_add`) to avoid reusing
  the exchange ID consumed by `ArmFailSafe`.
