### PR TITLE
add InteractionModelRevision to im_status_response and im_write_request

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -652,6 +652,7 @@ pub fn im_write_request(endpoint: u16, cluster: u32, attr: u32, exchange: u16, d
     tlv.write_struct_end()?;
     tlv.write_struct_end()?;
     tlv.write_bool(3, false)?;
+    tlv.write_uint8(0xff, 10)?; // InteractionModelRevision
     tlv.write_struct_end()?;
     Ok(tlv.data)
 }
@@ -786,6 +787,7 @@ pub fn im_status_response(exchange: u16, flags: u8, ack: u32) -> Result<Vec<u8>>
     let mut tlv = tlv::TlvBuffer::from_vec(b);
     tlv.write_anon_struct()?;
     tlv.write_uint8(0, 0)?;
+    tlv.write_uint8(0xff, 10)?; // InteractionModelRevision
     tlv.write_struct_end()?;
     Ok(tlv.data)
 }


### PR DESCRIPTION
Every Interaction Model action message must carry the mandatory `InteractionModelRevision` field (tag 0xFF). It is already written by `im_invoke_request`, `im_read_request`, `im_subscribe_request_attr`/`event`, `im_timed_request` and `im_unsubscribe_all`, but was missing on `im_status_response` and `im_write_request`.

Strict IM publishers (e.g. matter.js / Matterbridge) reject messages without it with `INVALID_ACTION` (0x80). For a StatusResponse sent in reply to a subscription `ReportData` this tears the subscription down, so no ongoing reports flow; lenient devices accept it, which is why it went unnoticed.

Adds a unit test pinning that both builders emit tag 0xFF.